### PR TITLE
Fix a typo that causes NullReference exception

### DIFF
--- a/Samples/MicrosoftGraph.Office365.Generic/OfficeDevPnP.MSGraphAPIDemo/Controllers/MailCalendarContactsController.cs
+++ b/Samples/MicrosoftGraph.Office365.Generic/OfficeDevPnP.MSGraphAPIDemo/Controllers/MailCalendarContactsController.cs
@@ -68,7 +68,7 @@ namespace OfficeDevPnP.MSGraphAPIDemo.Controllers
             var folders = MailHelper.ListFolders();
 
             // Here you can use whatever mailbox name that you like, instead of Inbox
-            var messages = MailHelper.ListMessages(folders.FirstOrDefault(f => f.Name == "Posta in arrivo" || f.Name == "Inobx").Id);
+            var messages = MailHelper.ListMessages(folders.FirstOrDefault(f => f.Name == "Posta in arrivo" || f.Name == "Inbox").Id);
             if (messages != null && messages.Count > 0)
             {
                 var message = MailHelper.GetMessage(messages[0].Id, true);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| New sample? | no |
| Related issues? | When testing sample **OfficeDevPnP.MSGraphAPIDemo**, you get a YSOD for mail API when clicking the button "Play with Mail Services" |

![09-10-2016 9-26-36 pm](https://cloud.githubusercontent.com/assets/2197158/19220032/29c32bdc-8e67-11e6-98c1-89f46d1bd785.png)
#### What's in this Pull Request?

Typo fix
